### PR TITLE
apache-tomcat-9.0.48のリンク切れを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="Koki Ota <ma20015@shibaura-it.ac.jp>"
 
 COPY startup.sh /startup.sh
@@ -7,7 +7,7 @@ RUN chmod 744 /startup.sh
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install openjdk-11-jdk curl openssh-server -y --no-install-recommends
 RUN useradd -M tomcat
-RUN curl -O https://downloads.apache.org/tomcat/tomcat-9/v9.0.48/bin/apache-tomcat-9.0.48.tar.gz
+RUN curl -O https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.48/bin/apache-tomcat-9.0.48.tar.gz
 RUN tar -xzvf apache-tomcat-9.0.48.tar.gz
 RUN mkdir /usr/local/java/
 RUN mv apache-tomcat-9.0.48 /usr/local/java/apache-tomcat-9.0.48


### PR DESCRIPTION
1，上級プログラミング２の講義資料でDockerのインストール方法の参考として挙げられていたページで，wslにubuntu20.04を使っていたので，１行目をubuntu20.04に変更
2，apache-tomcat-9.0.48.tar.gzがリンク切れだったようなので，10行目のリンクをアーカイブ版のほうに変更．

PCを買い替えたので改めて環境構築をしたところ，途中でDockerImageのビルドで詰まったので原因を調べてみました．
結果として，無事環境構築も終わって最終課題も終わりました（まだレポートが残ってますが）．

講義資料も結構古くなってるのでアップデートしてもらったほうが，私たち学生としてはうれしいです．参考までに，例えば上級プログラミング２，第７回講義資料，「第7回 Webプログラミング.pdf」の最後に参考として掲げられているWebサイトはすべてリンクが切れています．